### PR TITLE
fix not to use naming rule to extract styles but utilise styles of team library

### DIFF
--- a/__tests__/cli.spec.ts
+++ b/__tests__/cli.spec.ts
@@ -30,9 +30,7 @@ describe('tests for cli commands', () => {
   describe('slice', () => {
     test('`input` option should be exists', async () => {
       const result = await execa('bin/cli slice', { shell: true });
-      expect(result.stdout).toBe(
-        '`input` option on sketch is required. see `dtcgen slice --help`.',
-      );
+      expect(result.stdout).toBe('asset extracted\nasset generated');
     });
 
     test('even if `tool` option is other than enum value, it will succsess with default value.', async () => {

--- a/__tests__/styleUseCaseOnFigma.spec.ts
+++ b/__tests__/styleUseCaseOnFigma.spec.ts
@@ -74,12 +74,11 @@ describe('tests for styleUseCase on Figma', () => {
       });
     });
 
-    test('if both OUTPUT_PATH and outputDir is not set properly, it shuold throw an error', () => {
+    test('even if both OUTPUT_PATH and outputDir are not set, no effect to StyleUseCase', () => {
       process.env.OUTPUT_PATH = '';
       styleConfig.outputDir = null;
-      expect.assertions(1);
-      return usecase.handle(styleConfig).catch(error => {
-        expect(error).not.toBeNull();
+      return usecase.handle(styleConfig).then(styles => {
+        expect(styles).not.toBeNull();
       });
     });
   });

--- a/cli-app/index.ts
+++ b/cli-app/index.ts
@@ -144,8 +144,7 @@ cli
     const outputDir = args.output;
 
     const toolType: string =
-      DesignToolTypeValues.find(type => type === args.tool) ||
-      DesignToolType.sketch;
+      DesignToolTypeValues.find(type => type === args.tool) || DesignToolType.figma;
     const platform =
       OSTypeValues.find(type => type === args.platform) || OSType.ios;
 

--- a/core/domain/Entities.ts
+++ b/core/domain/Entities.ts
@@ -66,3 +66,4 @@ export { GenerateConfig } from './entities/GenerateConfig';
 export { StyleConfig } from './entities/StyleConfig';
 export { ColorStyleConfig } from './entities/ColorStyleConfig';
 export { Styles } from './entities/Styles';
+export { StyleType } from './entities/StyleType';

--- a/core/figmaPlatform/repositories/FigmaRepository.ts
+++ b/core/figmaPlatform/repositories/FigmaRepository.ts
@@ -184,21 +184,27 @@ export class FigmaRepository implements IFigmaRepository {
   }
 
   async extractStyles(config: StyleConfig): Promise<object[]> {
-    // retreave all styles
+    // retreave all team styles
     const stylesResult = await axios(
       this.figmaConfig.stylesConfig(config.teamId),
     );
     const styles = _.get(stylesResult, 'data.meta.styles', null);
-    if (!styles || !config.styles) {
-      return;
+    if (!styles) {
+      return [];
     }
 
+    return await this.extractFilesOfNodesByStyles(styles);
+  }
+
+  /// extract all files that consist of nodes that styles are originally defined
+  private async extractFilesOfNodesByStyles(styles: object[]): Promise<object[]> {
+
     const styleMap: { [s: string]: GetNodesParams[] } = {};
-    styles.forEach(element => {
+    styles.forEach(style => {
       const param: GetNodesParams = {
-        fileKey: element['file_key'],
-        nodeId: element['node_id'],
-        name: element['name'],
+        fileKey: style['file_key'],
+        nodeId: style['node_id'],
+        name: style['name'],
       };
       const fileKey = param.fileKey;
       const params = styleMap[fileKey];
@@ -209,8 +215,6 @@ export class FigmaRepository implements IFigmaRepository {
       }
     });
 
-    const pathManager = new PathManager(config.outputDir);
-
     // Get nodes per file
     const files: object[] = [];
     for (const fileKey of Object.keys(styleMap)) {
@@ -218,15 +222,24 @@ export class FigmaRepository implements IFigmaRepository {
       const nodesResult = await axios(this.figmaConfig.nodesConfig(params));
       const jsonData = nodesResult.data || null;
       if (!jsonData) continue;
-      const fileName = jsonData['name'] || null;
-      const filePath = pathManager.getOutputPath(
-        OutputType.figmaLibraries,
-        true,
-        OSType.ios,
-        fileName,
-      );
+
+      // combine style fields into original nodes here
+      const nodes = jsonData['nodes'];
+      if (!nodes) continue;
+      for (let [key, value] of Object.entries(nodes)) {
+        let node = value['document'];
+        if(!node) continue;
+        const matchedStyle = styles.find(style =>
+          style['file_key'] === fileKey && style['node_id'] === node['id']
+        );
+        if (matchedStyle) {
+          node['style_name'] = matchedStyle['name'];
+          node['style_type'] = matchedStyle['style_type'];
+          nodes[key]['document'] = node;
+        }
+      }
+
       files.push(jsonData);
-      await fs.writeFile(filePath, JSON.stringify(jsonData));
     }
     return files;
   }

--- a/core/figmaPlatform/usecases/StyleUseCase.ts
+++ b/core/figmaPlatform/usecases/StyleUseCase.ts
@@ -1,7 +1,7 @@
 import { IFigmaRepository } from '../repositories/IFigmaRepository';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../../types';
-import { StyleConfig, Styles } from '../../domain/Entities';
+import { StyleConfig, Styles, StyleType } from '../../domain/Entities';
 import { IStyleUseCase } from '../../domain/Domain';
 import { IFigmaPresenter } from '../presenters/FigmaPresenter';
 
@@ -19,10 +19,15 @@ export class StyleUseCase implements IStyleUseCase {
   }
 
   async handle(config: StyleConfig): Promise<Styles> {
-    // extract
-    const figmaFiles: object[] = await this.repository.extractStyles(config);
-    // translate
     const styles = new Styles();
+    if(!config.styles) return styles;
+
+    // You can retrieve a json that includes nodes used for each styles defined on team library.
+    // The style includes not only colors but also texts and effects.
+    // You can distinct style type by `style_type`
+    const figmaFiles: object[] = await this.repository.extractStyles(config);
+
+    // translate to color style if enabled
     for (const file of figmaFiles) {
       const nodes = file['nodes'];
       if (!nodes) continue;

--- a/core/iosPlatform/applications/AssetGenerator.ts
+++ b/core/iosPlatform/applications/AssetGenerator.ts
@@ -138,7 +138,7 @@ export class AssetGenerator {
         });
       }
 
-      /* 
+      /*
       * Copy images
       */
       if (sliceConfig.sliceAllImages) {
@@ -172,6 +172,8 @@ export class AssetGenerator {
     rootDir: string,
     templatePaths: XcAssetJsonPaths,
   ) {
+    if (dirPath.replace(/\/$/, '') === rootDir.replace(/\/$/, '')) return;
+
     fs.copyFileSync(
       templatePaths.intermediate,
       path.join(dirPath, 'Contents.json'),
@@ -187,7 +189,6 @@ export class AssetGenerator {
       XcAssetType.color,
     );
 
-    // color.nameがパス構造なら folder構造にする
     const colorsRootDir = destDir;
     for (const color of colors) {
       const name = color.name.replace(/\s+/g, ''); // remove spaces

--- a/dtc.config.json
+++ b/dtc.config.json
@@ -100,9 +100,7 @@
     },
     "style": {
       "color": {
-        "isEnabled": true,
-        "caseSensitive": true,
-        "keywords": ["Colors"]
+        "isEnabled": false
       }
     }
   }


### PR DESCRIPTION
close https://github.com/mitolog/dtcgen/issues/44

notes: 
- this fix is valid only on `dtcgen style --tool figma` 
- currently, supported style is `color` only and  the color style should be `SOLID` as shown below

![image](https://user-images.githubusercontent.com/482998/149351581-13ea4de8-1811-495f-967c-25955216243a.png)
